### PR TITLE
Update readme with linux dependency info.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,12 @@ ncurses frontend, but I'm unlikely to actually do that.
 
 There are also unit tests, which require [checkmk](http://mathias-kettner.de/checkmk.html)
 to work.
+
+
+### Compiling on Linux
+
+To compile on Linux you'll need to have the developer's libraries for ncurses. On a Debian based system installing those libraries might look something like:
+
+    sudo apt install libncurses5-dev
+
+Once you have the ncurses libraries you can run the make command.


### PR DESCRIPTION
@jvns I wasn't able to compile on Ubuntu 18.04 due to a missing ncurses library. Adding this note to README to address #7 